### PR TITLE
[KAA-1004] Changed peer.remove() to attach connect promise to State/Method

### DIFF
--- a/lib/jet/peer.js
+++ b/lib/jet/peer.js
@@ -222,6 +222,9 @@ Peer.prototype.add = function (stateOrMethod) {
  * @returns {external:Promise} Gets resolved as soon as the content has been removed from the Daemon.
  */
 Peer.prototype.remove = function (stateOrMethod) {
+  var that = this
+  stateOrMethod.jsonrpc = that.jsonrpc
+  stateOrMethod.connectPromise = this.connectPromise
   return stateOrMethod.remove()
 }
 


### PR DESCRIPTION
### Story

[KAA-1004](http://jira.genband.com:8080/browse/KAA-1004): peer.remove() should remove by path.

### Description

- The State/Method's `remove()` was throwing an error because it relies on the `peer`'s `add()` to attach the connect promise to the State/Method object
- `Peer`'s `remove()` now attaches the promise and the `jsonrpc` when it is called, so that the State/Method's `remove()` can reference it