### PR TITLE
Fix a bug where a local peer's event emitter was being removed

### DIFF
--- a/lib/jet/daemon/peers.js
+++ b/lib/jet/daemon/peers.js
@@ -16,7 +16,6 @@ var genPeerId = function (sock) {
       return sock.remoteAddress + ':' + sock.remotePort
     } catch (e) {
       // Assuming it's a local peer
-      console.log("ERROR: ", e);
       return `localPeer:${uuid.v1()}`
     }
   }

--- a/lib/jet/daemon/peers.js
+++ b/lib/jet/daemon/peers.js
@@ -15,7 +15,9 @@ var genPeerId = function (sock) {
       sock = sock._sender._socket
       return sock.remoteAddress + ':' + sock.remotePort
     } catch (e) {
-      return uuid.v1()
+      // Assuming it's a local peer
+      console.log("ERROR: ", e);
+      return `localPeer:${uuid.v1()}`
     }
   }
 }
@@ -64,7 +66,8 @@ exports.Peers = function (jsonrpc, elements) {
       try {
         jsonrpc.dispatch(peer, message)
       } catch (e) {
-        remove(peer)
+        const prefix = peer.id.split(':')[0]
+        if (prefix !== 'localPeer') remove(peer)
       }
     })
 

--- a/lib/jet/daemon/router.js
+++ b/lib/jet/daemon/router.js
@@ -35,7 +35,7 @@ exports.Router = function (log) {
             error: responseTimeout(message.params)
           })
         } catch (e) {
-          console.debug(`Failed to send timeout response to for ${message.id}`)
+          console.debug(`[node-jet|router.js] Failed to send timeout response to for ${message.id}`)
           console.debug(e)
         }
       }, timeout * 1000)


### PR DESCRIPTION
In node-jet, when a message fails to be sent to a peer through jsonrpc (which apparently happens quite a bit), the event emitter for that peer's state is removed. However, the daemon's local peer is a peer whose state we wouldn't like to remove, ever. 

To fix that, I created a condition which verifies if the message was to be sent to the local peer. To differentiate a normal peer ID from a local peer, I appended `localPeer` to its ID. To create that condition, I needed to differentiate a normal peer from a local peer when an ID was being generated.

It seems that the mock websocket that is created for the local peer is not exactly the same as a normal websocket, and is missing the `_socket` property in the `_sender` property. This causes a uuid to be generated as the ID instead of the IP:port of the websocket. I used this discrepancy to determine when it was a local peer, which after discovering that I could append `localPeer` as a prefix.